### PR TITLE
apitypes.yaml: fix typo in PushRequest object definition

### DIFF
--- a/api-spec/schemas/apitypes.yaml
+++ b/api-spec/schemas/apitypes.yaml
@@ -125,7 +125,7 @@ WakuMessage:
 PushRequest:
   type: object
   properties:
-    pusbsubTopic:
+    pubsubTopic:
       $ref: '#/PubsubTopic'
     message:
       $ref: '#/WakuMessage'


### PR DESCRIPTION
At some point we might need to do the following:
1. Remove all the definitions from the `nwaku` repo.
2. Add a reference to this repo, in the `nwaku` repo so that it is easy to find the actual API defs