### PR TITLE
fix: add `meta` field to `WakuMessage`, and `ephemeral` to `RelayWakuMessage`

### DIFF
--- a/api-spec/schemas/apitypes.yaml
+++ b/api-spec/schemas/apitypes.yaml
@@ -118,6 +118,9 @@ WakuMessage:
       format: int64
     ephemeral:
       type: boolean
+    meta:
+      type: string
+      format: byte
   required:
       - payload
       - contentTopic
@@ -146,6 +149,11 @@ RelayWakuMessage:
       type: number
     timestamp:
       type: number
+    ephemeral:
+      type: boolean
+    meta:
+      type: string
+      format: byte
   required:
     - payload
 


### PR DESCRIPTION
According to https://rfc.vac.dev/spec/14/,  the `meta` field is an optional application specific attribute, so it makes sense for devs to be able to specify this field when using relay. I also ended up adding `ephemeral` to `RelayWakuMessage` to not store the message.