### PR TITLE
fix: camelCase vs snake_case

### DIFF
--- a/api-spec/schemas/apitypes.yaml
+++ b/api-spec/schemas/apitypes.yaml
@@ -174,16 +174,16 @@ StoreResponse:
 HistoryCursor:
   type: object
   properties:
-    pubsub_topic:
+    pubsubTopic:
       type: string
-    sender_time:
+    senderTime:
       type: string
-    store_time:
+    storeTime:
       type: string
     digest:
       type: string
     required:
-      - pubsub_topic
-      - sender_time
-      - store_time
+      - pubsubTopic
+      - senderTime
+      - storeTime
       - digest


### PR DESCRIPTION
Curiously enough, the `HistoryCursor` was using snake_case, which was not consistent with all the attributes used in the rest of the types