### PR TITLE
feat: adding documentation for filter admin endpoint

### DIFF
--- a/api-spec/adminapi_filter.yaml
+++ b/api-spec/adminapi_filter.yaml
@@ -1,0 +1,19 @@
+get:
+  summary: Get filter protocol subscribers
+  description: Retrieve information about the serving filter subscriptions
+  operationId: getFilterInfo
+  tags:
+    - admin
+  responses:
+    '200':
+      description: Information about subscribed filter peers and topics
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "./schemas/apitypes.yaml#/FilterSubscription"
+    '400':
+      description: Filter Protocol is not mounted to the node
+    '5XX':
+      description: Unexpected error.

--- a/api-spec/openapi.yaml
+++ b/api-spec/openapi.yaml
@@ -29,6 +29,8 @@ tags:
 paths:
   /admin/v1/peers:
     $ref: "./adminapi.yaml"
+  /admin/v1/filter/subscriptions:
+    $ref: "./adminapi_filter.yaml"
   /debug/v1/info:
      $ref: "./debugapi_info.yaml"
   /debug/v1/version:

--- a/api-spec/schemas/apitypes.yaml
+++ b/api-spec/schemas/apitypes.yaml
@@ -187,3 +187,24 @@ HistoryCursor:
       - senderTime
       - storeTime
       - digest
+
+FilterSubscription:
+  type: object
+  required:
+    - peerId
+    - filterCriteria
+  properties:
+    peerId:
+      type: string
+    filterCriteria:
+      type: array
+      items:
+        type: object
+        required:
+          - pubsubTopic
+          - contentTopic
+        properties:
+          pubsubTopic:
+            type: string
+          contentTopic:
+            type: string


### PR DESCRIPTION
Documenting new `/admin/v1/filter/subscriptions` endpoint introduced in in https://github.com/waku-org/nwaku/pull/2314

![image](https://github.com/waku-org/waku-rest-api/assets/101006718/47368857-9ea5-49ff-af21-d4ec4df7c4a7)
