### PR TITLE
Chore: Non mandatory peerId for Store query 

### DIFF
--- a/api-spec/storeapi.yaml
+++ b/api-spec/storeapi.yaml
@@ -12,7 +12,6 @@ get:
       in: query
       schema:
         type: string
-      required: true
       description: >
         P2P fully qualified peer multiaddress
         in the format `(ip4|ip6)/tcp/p2p/$peerId` and URL-encoded.


### PR DESCRIPTION
Since store allows to query own node, we do not require peerId for the query as mandatory.