### PR TITLE
fix: Fixing typo in PushRequest object

### DIFF
--- a/api-spec/schemas/apitypes.yaml
+++ b/api-spec/schemas/apitypes.yaml
@@ -128,7 +128,7 @@ WakuMessage:
 PushRequest:
   type: object
   properties:
-    pusbsubTopic:
+    pubsubTopic:
       $ref: '#/PubsubTopic'
     message:
       $ref: '#/WakuMessage'


### PR DESCRIPTION
Found a typo in PushRequest object of Lightpush endpoint, fixing it.