### PR TITLE
fix: make WakuPeer origin field required

### DIFF
--- a/api-spec/schemas/apitypes.yaml
+++ b/api-spec/schemas/apitypes.yaml
@@ -3,6 +3,7 @@ WakuPeer:
   required:
     - multiaddr
     - protocols
+    - origin
   properties:
     multiaddr:
       type: string


### PR DESCRIPTION
Little fix after https://github.com/waku-org/waku-rest-api/pull/12