### PR TITLE
chore: specify that messages from relay and filter endpoints come from a cache of size 50

### DIFF
--- a/api-spec/filterapi_v2_messages.yaml
+++ b/api-spec/filterapi_v2_messages.yaml
@@ -1,7 +1,7 @@
 # /filter/v2/messages/{contentTopic}:
 get: # get_waku_v2_filter_v2_messages
   summary: Get the latest messages on the polled content topic
-  description: Get a list of messages that were received on a subscribed content topic after the last time this method was called.
+  description: Get a list of messages that were received on a subscribed content topic after the last time this method was called. Messages are selected from the last 50 messages received by the node.
   operationId: getMessagesByTopic
   tags:
     - filter

--- a/api-spec/relayapi_auto_content_topic.yaml
+++ b/api-spec/relayapi_auto_content_topic.yaml
@@ -1,7 +1,7 @@
 # /relay/v1/auto/messages/{contentTopic}:  # Note the plural in messages
 get: # get_waku_v2_relay_v1_auto_messages
   summary: Get the latest messages on the polled topic
-  description: Get a list of messages that were received on a subscribed Content topic after the last time this method was called.
+  description: Get a list of messages that were received on a subscribed Content topic after the last time this method was called. Messages are selected from the last 50 messages received by the node.
   operationId: getMessagesByTopic
   tags:
     - relay

--- a/api-spec/relayapi_auto_content_topic.yaml
+++ b/api-spec/relayapi_auto_content_topic.yaml
@@ -1,7 +1,7 @@
 # /relay/v1/auto/messages/{contentTopic}:  # Note the plural in messages
 get: # get_waku_v2_relay_v1_auto_messages
   summary: Get the latest messages on the polled topic
-  description: Get a list of messages that were received on a subscribed Content topic after the last time this method was called. By default, messages are selected from the last 30 messages received by the node. You can modify the number of cached messages with the --rest-relay-cache-capacity CLI parameter.
+  description: Get a list of messages that were received on a subscribed Content topic after the last time this method was called. By default, messages are selected from the last 30 messages received by the node. You can modify the number of cached messages with the --rest-relay-cache-capacity CLI argument.
   operationId: getMessagesByTopic
   tags:
     - relay

--- a/api-spec/relayapi_auto_content_topic.yaml
+++ b/api-spec/relayapi_auto_content_topic.yaml
@@ -1,7 +1,7 @@
 # /relay/v1/auto/messages/{contentTopic}:  # Note the plural in messages
 get: # get_waku_v2_relay_v1_auto_messages
   summary: Get the latest messages on the polled topic
-  description: Get a list of messages that were received on a subscribed Content topic after the last time this method was called. Messages are selected from the last 50 messages received by the node.
+  description: Get a list of messages that were received on a subscribed Content topic after the last time this method was called. By default, messages are selected from the last 30 messages received by the node. You can modify the number of cached messages with the --rest-relay-cache-capacity CLI parameter.
   operationId: getMessagesByTopic
   tags:
     - relay

--- a/api-spec/relayapi_messages.yaml
+++ b/api-spec/relayapi_messages.yaml
@@ -1,7 +1,7 @@
 # /relay/v1/messages/{pubsubTopic}:  # Note the plural in messages
 get: # get_waku_v2_relay_v1_messages
   summary: Get the latest messages on the polled topic
-  description: Get a list of messages that were received on a subscribed PubSub topic after the last time this method was called. Messages are selected from the last 50 messages received by the node.
+  description: Get a list of messages that were received on a subscribed PubSub topic after the last time this method was called. By default, messages are selected from the last 30 messages received by the node. You can modify the number of cached messages with the --rest-relay-cache-capacity CLI parameter.
   operationId: getMessagesByTopic
   tags:
     - relay

--- a/api-spec/relayapi_messages.yaml
+++ b/api-spec/relayapi_messages.yaml
@@ -1,7 +1,7 @@
 # /relay/v1/messages/{pubsubTopic}:  # Note the plural in messages
 get: # get_waku_v2_relay_v1_messages
   summary: Get the latest messages on the polled topic
-  description: Get a list of messages that were received on a subscribed PubSub topic after the last time this method was called. By default, messages are selected from the last 30 messages received by the node. You can modify the number of cached messages with the --rest-relay-cache-capacity CLI parameter.
+  description: Get a list of messages that were received on a subscribed PubSub topic after the last time this method was called. By default, messages are selected from the last 30 messages received by the node. You can modify the number of cached messages with the --rest-relay-cache-capacity CLI argument.
   operationId: getMessagesByTopic
   tags:
     - relay

--- a/api-spec/relayapi_messages.yaml
+++ b/api-spec/relayapi_messages.yaml
@@ -1,7 +1,7 @@
 # /relay/v1/messages/{pubsubTopic}:  # Note the plural in messages
 get: # get_waku_v2_relay_v1_messages
   summary: Get the latest messages on the polled topic
-  description: Get a list of messages that were received on a subscribed PubSub topic after the last time this method was called.
+  description: Get a list of messages that were received on a subscribed PubSub topic after the last time this method was called. Messages are selected from the last 50 messages received by the node.
   operationId: getMessagesByTopic
   tags:
     - relay


### PR DESCRIPTION
Specifying that messages are selected out of the last 50 received to avoid confusion or misusage by the users